### PR TITLE
fix: don't regenerate random secret values at helm upgrade and don't create secret if db-dependency is disabled

### DIFF
--- a/charts/portal/templates/secret-backend-external-db.yaml
+++ b/charts/portal/templates/secret-backend-external-db.yaml
@@ -2,10 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.externalDatabase.secret}}
+  name: {{ .Values.externalDatabase.secret }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.externalDatabase.secret) }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  portal-password: {{ ( .Values.externalDatabase.portalPassword | b64enc ) | default ( index $secret.data "portal-password" ) }}
+  provisioning-password: {{ ( .Values.externalDatabase.provisioningPassword | b64enc ) | default ( index $secret.data "provisioning-password" ) }}
+{{ else -}}
 stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
   portal-password: {{ .Values.externalDatabase.portalPassword | default ( randAlphaNum 32 | quote ) }}
   provisioning-password: {{ .Values.externalDatabase.provisioningPassword | default ( randAlphaNum 32 | quote ) }}
+{{ end }}
 {{- end -}}

--- a/charts/portal/templates/secret-backend-interfaces.yaml
+++ b/charts/portal/templates/secret-backend-interfaces.yaml
@@ -23,9 +23,24 @@ metadata:
   name: {{ .Values.backend.interfaces.secret }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.backend.interfaces.secret) }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  bpdm-client-secret: {{ ( .Values.backend.checklistworker.bpdm.clientSecret | b64enc ) | default ( index $secret.data "bpdm-client-secret" ) }}
+  clearinghouse-client-secret: {{ ( .Values.backend.checklistworker.clearinghouse.clientSecret | b64enc ) | default ( index $secret.data "clearinghouse-client-secret" ) }}
+  custodian-client-secret: {{ ( .Values.backend.checklistworker.custodian.clientSecret | b64enc ) | default ( index $secret.data "custodian-client-secret" ) }}
+  sdfactory-client-secret: {{ ( .Values.backend.checklistworker.sdfactory.clientSecret | b64enc ) | default ( index $secret.data "sdfactory-client-secret" ) }}
+  daps-client-secret: {{ ( .Values.backend.administration.daps.clientSecret | b64enc ) | default ( index $secret.data "daps-client-secret" ) }}
+{{ else -}}
 stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
   bpdm-client-secret: {{ .Values.backend.checklistworker.bpdm.clientSecret | default ( randAlphaNum 32 | quote ) }}
   clearinghouse-client-secret: {{ .Values.backend.checklistworker.clearinghouse.clientSecret | default ( randAlphaNum 32 | quote ) }}
   custodian-client-secret: {{ .Values.backend.checklistworker.custodian.clientSecret | default ( randAlphaNum 32 | quote ) }}
   sdfactory-client-secret: {{ .Values.backend.checklistworker.sdfactory.clientSecret | default ( randAlphaNum 32 | quote ) }}
   daps-client-secret: {{ .Values.backend.administration.daps.clientSecret | default ( randAlphaNum 32 | quote ) }}
+{{ end }}

--- a/charts/portal/templates/secret-backend-keycloak.yaml
+++ b/charts/portal/templates/secret-backend-keycloak.yaml
@@ -23,7 +23,20 @@ metadata:
   name: {{ .Values.backend.keycloak.secret }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.backend.keycloak.secret) }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  central-db-password: {{ ( .Values.backend.keycloak.central.dbConnection.password | b64enc ) | default ( index $secret.data "central-db-password" ) }}
+  central-client-secret: {{ ( .Values.backend.keycloak.central.clientSecret | b64enc ) | default ( index $secret.data "central-client-secret" ) }}
+  shared-client-secret: {{ ( .Values.backend.keycloak.shared.clientSecret | b64enc ) | default ( index $secret.data "shared-client-secret" ) }}
+{{ else -}}
 stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
   central-db-password: {{ .Values.backend.keycloak.central.dbConnection.password | default ( randAlphaNum 32 | quote ) }}
   central-client-secret: {{ .Values.backend.keycloak.central.clientSecret | default ( randAlphaNum 32 | quote ) }}
   shared-client-secret: {{ .Values.backend.keycloak.shared.clientSecret | default ( randAlphaNum 32 | quote ) }}
+{{ end }}

--- a/charts/portal/templates/secret-backend-mailing.yaml
+++ b/charts/portal/templates/secret-backend-mailing.yaml
@@ -23,6 +23,19 @@ metadata:
   name: {{ .Values.backend.mailing.secret }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.backend.mailing.secret) }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  password: {{ ( .Values.backend.mailing.password | b64enc ) | default $secret.data.password }}
+  provisioning-sharedrealm-password: {{ ( .Values.backend.provisioning.sharedRealm.smtpServer.password | b64enc ) | default ( index $secret.data "provisioning-sharedrealm-password" ) }}
+{{ else -}}
 stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
   password: {{ .Values.backend.mailing.password | default ( randAlphaNum 32 | quote ) }}
   provisioning-sharedrealm-password: {{ .Values.backend.provisioning.sharedRealm.smtpServer.password | default ( randAlphaNum 32 | quote ) }}
+{{ end }}
+  

--- a/charts/portal/templates/secret-backend-mailing.yaml
+++ b/charts/portal/templates/secret-backend-mailing.yaml
@@ -38,4 +38,3 @@ stringData:
   password: {{ .Values.backend.mailing.password | default ( randAlphaNum 32 | quote ) }}
   provisioning-sharedrealm-password: {{ .Values.backend.provisioning.sharedRealm.smtpServer.password | default ( randAlphaNum 32 | quote ) }}
 {{ end }}
-  

--- a/charts/portal/templates/secret-backend-postgres-init.yaml
+++ b/charts/portal/templates/secret-backend-postgres-init.yaml
@@ -1,22 +1,4 @@
-###############################################################
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-###############################################################
-
+{{- if .Values.postgresql.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -42,3 +24,4 @@ stringData:
   portal-password: {{ .Values.postgresql.auth.portalPassword | default ( randAlphaNum 32 | quote ) }}
   provisioning-password: {{ .Values.postgresql.auth.provisioningPassword | default ( randAlphaNum 32 | quote ) }}
 {{ end }}
+{{- end -}}

--- a/charts/portal/templates/secret-backend-postgres-init.yaml
+++ b/charts/portal/templates/secret-backend-postgres-init.yaml
@@ -23,8 +23,22 @@ metadata:
   name: {{ .Values.postgresql.auth.existingSecret }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.postgresql.auth.existingSecret) }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  postgres-password: {{ ( .Values.postgresql.auth.password | b64enc )  | default ( index $secret.data "postgres-password" ) }}
+  replication-password: {{ ( .Values.postgresql.auth.replicationPassword | b64enc )  | default ( index $secret.data "replication-password" ) }}
+  portal-password: {{ ( .Values.postgresql.auth.portalPassword | b64enc ) | default ( index $secret.data "portal-password" ) }}
+  provisioning-password: {{ ( .Values.postgresql.auth.provisioningPassword | b64enc ) | default ( index $secret.data "provisioning-password" ) }}
+{{ else -}}
 stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
   postgres-password: {{ .Values.postgresql.auth.password | default ( randAlphaNum 32 | quote ) }}
   replication-password: {{ .Values.postgresql.auth.replicationPassword | default ( randAlphaNum 32 | quote ) }}
   portal-password: {{ .Values.postgresql.auth.portalPassword | default ( randAlphaNum 32 | quote ) }}
   provisioning-password: {{ .Values.postgresql.auth.provisioningPassword | default ( randAlphaNum 32 | quote ) }}
+{{ end }}


### PR DESCRIPTION
- fix(secrets): use existing secret values if secret exists -> why?: helm upgrade is failing in the case of usage of randomly generated secret values because the database still has the credentials from before helm upgrade; the upgrades then fails with 'Error: INSTALLATION FAILED: failed post-install: timed out waiting for the condition' because the portal migration job (hook, running after every upgrade) fails at the db authentication.
ref: https://github.com/eclipse-tractusx/portal-cd/issues/9 and CPLP-2539
- fix(db): don't create secret if dependency is disabled