### PR TITLE
chore(auto-image-update): move from values-dev to default values file

### DIFF
--- a/.github/workflows/administration-service-image-update.yml
+++ b/.github/workflows/administration-service-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for administration service"
           bash ./scripts/push.sh

--- a/.github/workflows/maintenance-service-image-update.yml
+++ b/.github/workflows/maintenance-service-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for maintenance service"
           bash ./scripts/push.sh

--- a/.github/workflows/marketplace-app-service-image-update.yml
+++ b/.github/workflows/marketplace-app-service-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for marketplace-app service"
           bash ./scripts/push.sh

--- a/.github/workflows/notification-service-image-update.yml
+++ b/.github/workflows/notification-service-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for notification service"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-assets-image-update.yml
+++ b/.github/workflows/portal-assets-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for portal assets"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-image-update.yml
+++ b/.github/workflows/portal-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for portal"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-migrations-image-update.yml
+++ b/.github/workflows/portal-migrations-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for portal-migrations"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-registration-image-update.yml
+++ b/.github/workflows/portal-registration-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for portal registration"
           bash ./scripts/push.sh

--- a/.github/workflows/processes-worker-image-update.yml
+++ b/.github/workflows/processes-worker-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for processes worker"
           bash ./scripts/push.sh

--- a/.github/workflows/provisioning-migrations-image-update.yml
+++ b/.github/workflows/provisioning-migrations-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for provisioning-migrations"
           bash ./scripts/push.sh

--- a/.github/workflows/provisioning-service-image-update.yml
+++ b/.github/workflows/provisioning-service-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for provisioning service"
           bash ./scripts/push.sh

--- a/.github/workflows/registration-service-image-update.yml
+++ b/.github/workflows/registration-service-image-update.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for registration service"
           bash ./scripts/push.sh

--- a/.github/workflows/services-service-image-update.yml
+++ b/.github/workflows/services-service-image-update.yml
@@ -41,15 +41,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-dev.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-dev.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-dev.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-dev.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new image for services service"
           bash ./scripts/push.sh
 

--- a/charts/portal/values-dev.yaml
+++ b/charts/portal/values-dev.yaml
@@ -63,18 +63,6 @@ frontend:
               service: "assets"
               port: 8080
 
-  portal:
-    image:
-      portaltag: 99014443ae3cd5fdb263aae5878872cebb016e77
-
-  assets:
-    image:
-      assetstag: bc6ad08b7d68d2ebe01d638629a836054ff75524
-
-  registration:
-    image:
-      registrationtag: 16bb727d44d4e90c840da517797e0ca543bd6868
-
 backend:
   ingress:
     enabled: true
@@ -139,8 +127,6 @@ backend:
     password: "<path:portal/data/mailing#password>"
 
   registration:
-    image:
-      registrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       registrationServiceBpn: "Debug"
     healthChecks:
@@ -153,8 +139,6 @@ backend:
     swaggerEnabled: true
 
   administration:
-    image:
-      administrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
@@ -182,8 +166,6 @@ backend:
         from: "<path:portal/data/mailing#from>"
         replyTo: "<path:portal/data/mailing#replyto>"
     service:
-      image:
-        provisioningservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
       healthChecks:
         startup:
           tags:
@@ -194,8 +176,6 @@ backend:
       swaggerEnabled: true
 
   appmarketplace:
-    image:
-      appmarketplaceservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       offersLibrary: "Debug"
     healthChecks:
@@ -208,18 +188,10 @@ backend:
     swaggerEnabled: true
 
   portalmigrations:
-    image:
-      portalmigrationstag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     seeding:
       testDataEnvironments: "consortia"
 
-  portalmaintenance:
-    image:
-      portalmaintenancetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
-
   notification:
-    image:
-      notificationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     healthChecks:
       startup:
         tags:
@@ -230,8 +202,6 @@ backend:
     swaggerEnabled: true
 
   services:
-    image:
-      servicesservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       offersLibrary: "Debug"
     healthChecks:
@@ -243,13 +213,7 @@ backend:
           value: "portaldb"
     swaggerEnabled: true
 
-  provisioningmigrations:
-    image:
-      provisioningmigrationstag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
-
   processesworker:
-    image:
-      processesworkertag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       processesLibrary: "Debug"
       bpdmLibrary: "Debug"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -100,12 +100,12 @@ frontend:
     name: "registration"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-frontend-registration"
-      registrationtag: bc6ad08b7d68d2ebe01d638629a836054ff75524
+      registrationtag: 16bb727d44d4e90c840da517797e0ca543bd6868
   assets:
     name: "assets"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-assets"
-      assetstag: 16bb727d44d4e90c840da517797e0ca543bd6868
+      assetstag: bc6ad08b7d68d2ebe01d638629a836054ff75524
     path: "/assets"
   centralidpAuthPath: "/auth"
   bpdmPartnersPoolApiPath: "/api"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -95,17 +95,17 @@ frontend:
     name: "portal"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-frontend"
-      portaltag: v1.4.0
+      portaltag: 99014443ae3cd5fdb263aae5878872cebb016e77
   registration:
     name: "registration"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-frontend-registration"
-      registrationtag: v1.3.0-RC2
+      registrationtag: bc6ad08b7d68d2ebe01d638629a836054ff75524
   assets:
     name: "assets"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-assets"
-      assetstag: v1.3.0-RC3
+      assetstag: 16bb727d44d4e90c840da517797e0ca543bd6868
     path: "/assets"
   centralidpAuthPath: "/auth"
   bpdmPartnersPoolApiPath: "/api"
@@ -225,7 +225,7 @@ backend:
     name: "registration-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_registration-service"
-      registrationservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      registrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       registrationServiceBpn: "Information"
     healthChecks:
@@ -252,7 +252,7 @@ backend:
     name: "administration-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_administration-service"
-      administrationservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      administrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       businessLogic: "Information"
       sdfactoryLibrary: "Information"
@@ -342,7 +342,7 @@ backend:
       name: "provisioning-service"
       image:
         name: "ghcr.io/catenax-ng/tx-portal-backend_provisioning-service"
-        provisioningservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+        provisioningservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
       healthChecks:
         startup:
           tags: []
@@ -356,7 +356,7 @@ backend:
     name: "marketplace-app-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_marketplace-app-service"
-      appmarketplaceservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      appmarketplaceservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       offersLibrary: "Information"
     healthChecks:
@@ -423,19 +423,19 @@ backend:
     name: "portal-migrations"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_portal-migrations"
-      portalmigrationstag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      portalmigrationstag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     seeding:
       testDataEnvironments: ""
   portalmaintenance:
     name: "portal-maintenance"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_maintenance-service"
-      portalmaintenancetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      portalmaintenancetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
   notification:
     name: "notification-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_notification-service"
-      notificationservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      notificationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     healthChecks:
       startup:
         tags: []
@@ -449,7 +449,7 @@ backend:
     name: "services-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_services-service"
-      servicesservicetag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      servicesservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       offersLibrary: "Information"
     healthChecks:
@@ -499,12 +499,12 @@ backend:
     name: "provisioning-migrations"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_provisioning-migrations"
-      provisioningmigrationstag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      provisioningmigrationstag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
   processesworker:
     name: "processes-worker"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_processes-worker"
-      processesworkertag: e861151aa106922ea95b70bd6a1061adcb2ff1ae
+      processesworkertag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
     logging:
       processesLibrary: "Information"
       bpdmLibrary: "Information"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -95,7 +95,7 @@ frontend:
     name: "portal"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-frontend"
-      portaltag: 99014443ae3cd5fdb263aae5878872cebb016e77
+      portaltag: 25f571ad965cceaf8946b401237a5304ca1df012
   registration:
     name: "registration"
     image:
@@ -225,7 +225,7 @@ backend:
     name: "registration-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_registration-service"
-      registrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
+      registrationservicetag: f54fd52b79d52b9a250a2984d15714f0c26c21cb
     logging:
       registrationServiceBpn: "Information"
     healthChecks:
@@ -252,7 +252,7 @@ backend:
     name: "administration-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_administration-service"
-      administrationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
+      administrationservicetag: f54fd52b79d52b9a250a2984d15714f0c26c21cb
     logging:
       businessLogic: "Information"
       sdfactoryLibrary: "Information"
@@ -356,7 +356,7 @@ backend:
     name: "marketplace-app-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_marketplace-app-service"
-      appmarketplaceservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
+      appmarketplaceservicetag: f54fd52b79d52b9a250a2984d15714f0c26c21cb
     logging:
       offersLibrary: "Information"
     healthChecks:
@@ -435,7 +435,7 @@ backend:
     name: "notification-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_notification-service"
-      notificationservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
+      notificationservicetag: f54fd52b79d52b9a250a2984d15714f0c26c21cb
     healthChecks:
       startup:
         tags: []
@@ -449,7 +449,7 @@ backend:
     name: "services-service"
     image:
       name: "ghcr.io/catenax-ng/tx-portal-backend_services-service"
-      servicesservicetag: d37d04846cf61ebbc40aa1f7a05b4ee25cedfe93
+      servicesservicetag: f54fd52b79d52b9a250a2984d15714f0c26c21cb
     logging:
       offersLibrary: "Information"
     healthChecks:


### PR DESCRIPTION
### Why?
Updating the values-dev.yaml is obsolete by now as the helm-environments branch is only installed on the dev environment.
At the same time updating (only) the values-dev file causes issues with the helm test workflow in the case of breaking config changes, as the workflow requires the image to be updated in the default values file.