### PR TITLE
chore: move from values-rc to default values file and align env values file with values-dev

### DIFF
--- a/.github/workflows/portal-assets-rc-image-update.yml
+++ b/.github/workflows/portal-assets-rc-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-rc.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-rc.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-rc.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new images for RC portal assets"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-backend-rc-image-update.yml
+++ b/.github/workflows/portal-backend-rc-image-update.yml
@@ -59,23 +59,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-rc.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.ADMINISTRATION_IMAGE_BEGINN }}.*/${{ env.ADMINISTRATION_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.PROCESSES_IMAGE_BEGINN }}.*/${{ env.PROCESSES_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.PORTALMAINTENANCE_IMAGE_BEGINN }}.*/${{ env.PORTALMAINTENANCE_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.APPMARKETPLACE_IMAGE_BEGINN }}.*/${{ env.APPMARKETPLACE_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.NOTIFICATION_IMAGE_BEGINN }}.*/${{ env.NOTIFICATION_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.PORTALMIGRATIONS_IMAGE_BEGINN }}.*/${{ env.PORTALMIGRATIONS_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.PROVISIONING_IMAGE_BEGINN }}.*/${{ env.PROVISIONING_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.REGISTRATION_IMAGE_BEGINN }}.*/${{ env.REGISTRATION_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.SERVICES_IMAGE_BEGINN }}.*/${{ env.SERVICES_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
-          sed -i 's/${{ env.PROVISIONINGMIGRATIONS_IMAGE_BEGINN }}.*/${{ env.PROVISIONINGMIGRATIONS_IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
+          sed -i 's/${{ env.ADMINISTRATION_IMAGE_BEGINN }}.*/${{ env.ADMINISTRATION_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.PROCESSES_IMAGE_BEGINN }}.*/${{ env.PROCESSES_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.PORTALMAINTENANCE_IMAGE_BEGINN }}.*/${{ env.PORTALMAINTENANCE_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.APPMARKETPLACE_IMAGE_BEGINN }}.*/${{ env.APPMARKETPLACE_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.NOTIFICATION_IMAGE_BEGINN }}.*/${{ env.NOTIFICATION_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.PORTALMIGRATIONS_IMAGE_BEGINN }}.*/${{ env.PORTALMIGRATIONS_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.PROVISIONING_IMAGE_BEGINN }}.*/${{ env.PROVISIONING_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.REGISTRATION_IMAGE_BEGINN }}.*/${{ env.REGISTRATION_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.SERVICES_IMAGE_BEGINN }}.*/${{ env.SERVICES_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
+          sed -i 's/${{ env.PROVISIONINGMIGRATIONS_IMAGE_BEGINN }}.*/${{ env.PROVISIONINGMIGRATIONS_IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-rc.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-rc.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new images for RC portal backend"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-rc-image-update.yml
+++ b/.github/workflows/portal-rc-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-rc.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-rc.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-rc.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new images for RC portal"
           bash ./scripts/push.sh

--- a/.github/workflows/portal-registration-rc-image-update.yml
+++ b/.github/workflows/portal-registration-rc-image-update.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Modify image tag in values-rc.yaml
+      - name: Modify image tag in values.yaml
         run: |
-          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values-rc.yaml
+          sed -i 's/${{ env.IMAGE_BEGINN }}.*/${{ env.IMAGE_FULL_NEW }}/' charts/portal/values.yaml
 
-      - name: Commit and push updated values-rc.yaml
+      - name: Commit and push updated values.yaml
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add charts/portal/values-rc.yaml
+          git add charts/portal/values.yaml
           git commit -m "Add new images for RC portal registration"
           bash ./scripts/push.sh

--- a/charts/portal/values-beta.yaml
+++ b/charts/portal/values-beta.yaml
@@ -142,9 +142,6 @@ backend:
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
-    daps:
-      clientId: "<path:portal/data/administration#daps-client-id>"
-      clientSecret: "<path:portal/data/beta/administration#daps-client-secret>"
     healthChecks:
       startup:
         tags:
@@ -154,6 +151,9 @@ backend:
           value: "portaldb"
         - name: "HEALTHCHECKS__0__TAGS__2"
           value: "provisioningdb"
+    daps:
+      clientId: "<path:portal/data/administration#daps-client-id>"
+      clientSecret: "<path:portal/data/beta/administration#daps-client-secret>"
     swaggerEnabled: true
 
   provisioning:
@@ -215,7 +215,7 @@ backend:
 
   processesworker:
     logging:
-      checklistLibrary: "Debug"
+      processesLibrary: "Debug"
       bpdmLibrary: "Debug"
       clearinghouseLibrary: "Debug"
       custodianLibrary: "Debug"

--- a/charts/portal/values-int.yaml
+++ b/charts/portal/values-int.yaml
@@ -142,9 +142,6 @@ backend:
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
-    daps:
-      clientId: "<path:portal/data/administration#daps-client-id>"
-      clientSecret: "<path:portal/data/int/administration#daps-client-secret>"
     healthChecks:
       startup:
         tags:
@@ -154,6 +151,9 @@ backend:
           value: "portaldb"
         - name: "HEALTHCHECKS__0__TAGS__2"
           value: "provisioningdb"
+    daps:
+      clientId: "<path:portal/data/administration#daps-client-id>"
+      clientSecret: "<path:portal/data/int/administration#daps-client-secret>"
     swaggerEnabled: true
 
   provisioning:
@@ -215,7 +215,7 @@ backend:
 
   processesworker:
     logging:
-      checklistLibrary: "Debug"
+      processesLibrary: "Debug"
       bpdmLibrary: "Debug"
       clearinghouseLibrary: "Debug"
       custodianLibrary: "Debug"

--- a/charts/portal/values-pen.yaml
+++ b/charts/portal/values-pen.yaml
@@ -143,9 +143,6 @@ backend:
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
-    daps:
-      clientId: "<path:portal/data/administration#daps-client-id>"
-      clientSecret: "<path:portal/data/pen/administration#daps-client-secret>"
     healthChecks:
       startup:
         tags:
@@ -155,6 +152,9 @@ backend:
           value: "portaldb"
         - name: "HEALTHCHECKS__0__TAGS__2"
           value: "provisioningdb"
+    daps:
+      clientId: "<path:portal/data/administration#daps-client-id>"
+      clientSecret: "<path:portal/data/pen/administration#daps-client-secret>"
     swaggerEnabled: true
 
   provisioning:
@@ -216,7 +216,7 @@ backend:
 
   processesworker:
     logging:
-      checklistLibrary: "Debug"
+      processesLibrary: "Debug"
       bpdmLibrary: "Debug"
       clearinghouseLibrary: "Debug"
       custodianLibrary: "Debug"

--- a/charts/portal/values-preprod.yaml
+++ b/charts/portal/values-preprod.yaml
@@ -142,9 +142,6 @@ backend:
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
-    daps:
-      clientId: "<path:portal/data/administration#daps-client-id>"
-      clientSecret: "<path:portal/data/pre-prod/administration#daps-client-secret>"
     healthChecks:
       startup:
         tags:
@@ -154,6 +151,9 @@ backend:
           value: "portaldb"
         - name: "HEALTHCHECKS__0__TAGS__2"
           value: "provisioningdb"
+    daps:
+      clientId: "<path:portal/data/administration#daps-client-id>"
+      clientSecret: "<path:portal/data/pre-prod/administration#daps-client-secret>"
     swaggerEnabled: true
 
   provisioning:
@@ -215,7 +215,7 @@ backend:
 
   processesworker:
     logging:
-      checklistLibrary: "Debug"
+      processesLibrary: "Debug"
       bpdmLibrary: "Debug"
       clearinghouseLibrary: "Debug"
       custodianLibrary: "Debug"

--- a/charts/portal/values-rc.yaml
+++ b/charts/portal/values-rc.yaml
@@ -63,18 +63,6 @@ frontend:
               service: "assets"
               port: 8080
 
-  portal:
-    image:
-      portaltag: 71f0ce6c85aa17ed1926559120ffe5871666bfa7
-
-  assets:
-    image:
-      assetstag: c25e9a5a8ddae7d87ab1d9c4194efe93929d0d4c
-
-  registration:
-    image:
-      registrationtag: b9c409d1c44684e50f2517f868d71585fc661f91
-
 backend:
   ingress:
     enabled: true
@@ -139,8 +127,6 @@ backend:
     password: "<path:portal/data/mailing#password>"
 
   registration:
-    image:
-      registrationservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
       registrationServiceBpn: "Debug"
     healthChecks:
@@ -153,8 +139,6 @@ backend:
     swaggerEnabled: true
 
   administration:
-    image:
-      administrationservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
@@ -182,8 +166,6 @@ backend:
         from: "<path:portal/data/mailing#from>"
         replyTo: "<path:portal/data/mailing#replyto>"
     service:
-      image:
-        provisioningservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
       healthChecks:
         startup:
           tags:
@@ -194,8 +176,6 @@ backend:
       swaggerEnabled: true
 
   appmarketplace:
-    image:
-      appmarketplaceservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
       offersLibrary: "Debug"
     healthChecks:
@@ -208,18 +188,10 @@ backend:
     swaggerEnabled: true
 
   portalmigrations:
-    image:
-      portalmigrationstag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     seeding:
       testDataEnvironments: "consortia"
 
-  portalmaintenance:
-    image:
-      portalmaintenancetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
-
   notification:
-    image:
-      notificationservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     healthChecks:
       startup:
         tags:
@@ -230,8 +202,6 @@ backend:
     swaggerEnabled: true
 
   services:
-    image:
-      servicesservicetag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
       offersLibrary: "Debug"
     healthChecks:
@@ -243,13 +213,7 @@ backend:
           value: "portaldb"
     swaggerEnabled: true
 
-  provisioningmigrations:
-    image:
-      provisioningmigrationstag: f85b253a09b707c30efc89fd58db74a69c4c55a0
-
   processesworker:
-    image:
-      processesworkertag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
       processesLibrary: "Debug"
       bpdmLibrary: "Debug"

--- a/charts/portal/values-rc.yaml
+++ b/charts/portal/values-rc.yaml
@@ -158,9 +158,6 @@ backend:
     logging:
       businessLogic: "Debug"
       sdfactoryLibrary: "Debug"
-    daps:
-      clientId: "<path:portal/data/administration#daps-client-id>"
-      clientSecret: "<path:portal/data/dev/administration#daps-client-secret>"
     healthChecks:
       startup:
         tags:
@@ -170,6 +167,9 @@ backend:
           value: "portaldb"
         - name: "HEALTHCHECKS__0__TAGS__2"
           value: "provisioningdb"
+    daps:
+      clientId: "<path:portal/data/administration#daps-client-id>"
+      clientSecret: "<path:portal/data/dev/administration#daps-client-secret>"
     swaggerEnabled: true
 
   provisioning:
@@ -251,7 +251,7 @@ backend:
     image:
       processesworkertag: f85b253a09b707c30efc89fd58db74a69c4c55a0
     logging:
-      checklistLibrary: "Debug"
+      processesLibrary: "Debug"
       bpdmLibrary: "Debug"
       clearinghouseLibrary: "Debug"
       custodianLibrary: "Debug"


### PR DESCRIPTION
### Why?
- align env values file with values-dev: keep env specific value files easy to maintain
- auto-image-update - move from values-rc to default values file: updating the values-rc.yaml is obsolete by now as the release-candidate branch is only installed on the rc environment.
At the same time updating (only) the values-rc file causes issues with the helm test workflow in the case of breaking config changes, as the workflow requires the image to be updated in the default values file. --> related to https://github.com/catenax-ng/tx-portal-cd/pull/80